### PR TITLE
Removing the access to the attribute 'type' during an Add Attribute

### DIFF
--- a/typhonql/src/lang/typhonml/XMIReader.rsc
+++ b/typhonql/src/lang/typhonml/XMIReader.rsc
@@ -504,9 +504,7 @@ Model xmiNode2Model(node n) {
       	}
 
       	case "typhonml:AddAttribute":{
-      		t = get(xcho, "type");
-      		
-      		// TODO replace by actual type
+      	
       		DataType dt = DataType(realm.new(#IntType, IntType())); 
       		ty = referTo(#DataType, dt);
 


### PR DESCRIPTION
Hi,

I identified an issue with the xmi reader. If the XMI schema contains an _AddAttribute_ change operator the parsing fails.
The error is due to a line trying to access the "type" attribute of the AddAttribute. As that attribute does not exist anymore it causes the error.

I propose this quick fix for you. As I do not use the information about the type of the new entity and as I am the only one using the change operator part of the QL XMI Reader I propose to remove the line causing the issue.

Have a good day

Jérôme